### PR TITLE
Add attribute entity type text to handle holding of multiple options

### DIFF
--- a/src/ProductInfo.php
+++ b/src/ProductInfo.php
@@ -483,7 +483,7 @@ class ProductInfo implements Feed
         }
 
         $isMultiple['catalog_product_entity_varchar'] = new Expression('(attribute.value REGEXP ?)', '^[0-9]+,');
-
+        $isMultiple['catalog_product_entity_text'] = new Expression('(attribute.value REGEXP ?)', '^[0-9]+,');
 
         $attributeCodeToId = array_flip($attributeIds);
         foreach ($conditionGenerator->conditions() as $condition) {


### PR DESCRIPTION
catalog_product_entity_text can also handle multiple product options fro attribute.
Example is shipperHQ module data

![image](https://user-images.githubusercontent.com/4994260/135630983-633003fe-4851-4719-a554-bbc9929bbfba.png)
