### PR TITLE
add attribute only, product data only and base64 encode/decode options

### DIFF
--- a/src/CsvReader.php
+++ b/src/CsvReader.php
@@ -11,7 +11,7 @@ namespace EcomDev\MagentoMigration;
 
 class CsvReader
 {
-    public function readFile(string $fileName): iterable
+    public function readFile(string $fileName, bool $decodeData = false): iterable
     {
         if (!file_exists($fileName)) {
             return;
@@ -25,7 +25,9 @@ class CsvReader
             if (count($row) < count($headers)) {
                 continue;
             }
-
+            if($decodeData) {
+                $row = array_map('base64_decode', $row);
+            }
             $item =  array_combine($headers, $row);
             yield $item;
         }

--- a/src/CsvWriter.php
+++ b/src/CsvWriter.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace EcomDev\MagentoMigration;
 
 
+use phpDocumentor\Reflection\Types\Boolean;
+
 class CsvWriter
 {
     /**
@@ -30,12 +32,18 @@ class CsvWriter
      */
     private $mapping;
 
-    public function __construct(\SplFileObject $writer, array $headers, array $skipConditions, array $mapping)
+    /**
+     * @var Boolean
+     */
+    private $encodeData;
+
+    public function __construct(\SplFileObject $writer, array $headers, array $skipConditions, array $mapping, bool $encodeData = false)
     {
         $this->writer = $writer;
         $this->headers = $headers;
         $this->skipConditions = $skipConditions;
         $this->mapping = $mapping;
+        $this->encodeData = $encodeData;
     }
 
     public function write(array $row): void
@@ -73,7 +81,9 @@ class CsvWriter
 
             $csvRow[] = (string)$value;
         }
-
+        if ($this->encodeData) {
+            $csvRow = array_map('base64_encode', $csvRow);
+        }
         $this->writer->fputcsv($csvRow);
     }
 }

--- a/src/ExportApplication.php
+++ b/src/ExportApplication.php
@@ -54,12 +54,18 @@ class ExportApplication
                 $this->exportFactory = $this->exportFactory->withConfiguration((array)$configuration);
             }
 
-            $export = $this->exportFactory->create($path, $adapter);
+            $export = $this->exportFactory->create($path, $adapter, (bool) $cli->arguments->get('encode_data'));
 
-            $export->exportAttributes();
-            $export->exportCategories();
-            $export->exportProducts();
-            $export->exportCustomers();
+            if($cli->arguments->get('attributes_only')) {
+                $export->exportAttributes();
+            } else if($cli->arguments->get('products_data_only')) {
+                $export->exportProductsDataOnly();
+            } else {
+                $export->exportAttributes();
+                $export->exportCategories();
+                $export->exportProducts();
+                $export->exportCustomers();
+            }
         } catch (InvalidArgumentException $e) {
             $cli->error($e->getMessage());
             $cli->usage();
@@ -105,6 +111,27 @@ class ExportApplication
         $cli->arguments->add('target_path', [
             'description' => 'MagentoExport Directory',
             'required' => true
+        ]);
+
+        $cli->arguments->add('attributes_only', [
+            'prefix' => 'a',
+            'longPrefix' => 'attributes-only',
+            'description' => 'Only export Attribute data',
+            'defaultValue' => 0
+        ]);
+
+        $cli->arguments->add('products_data_only', [
+            'prefix' => 'po',
+            'longPrefix' => 'products-data-only',
+            'description' => 'Only export product data',
+            'defaultValue' => 0
+        ]);
+
+        $cli->arguments->add('encode_data', [
+            'prefix' => 'ed',
+            'longPrefix' => 'encode_data',
+            'description' => 'Bae 64 encode data to csv file',
+            'defaultValue' => 0
         ]);
     }
 }

--- a/src/Import.php
+++ b/src/Import.php
@@ -47,6 +47,15 @@ class Import
         $this->customerImport = $customerImport;
     }
 
+    public function importAttributesOnly()
+    {
+        $this->eavMetadataImport->importAttributes($this->csvFactory->createReader('attribute.csv'));
+
+        $this->eavMetadataImport->importAttributeSets($this->csvFactory->createReader('attribute_set.csv'));
+
+        $this->eavMetadataImport->importAttributeOptions($this->csvFactory->createReader('attribute_option.csv'));
+    }
+
     public function importAttributes()
     {
         $this->eavMetadataImport->importAttributes($this->csvFactory->createReader('attribute.csv'));
@@ -60,6 +69,12 @@ class Import
     {
         $this->categoryImport->importCategories($this->csvFactory->createReader('category.csv'));
         $this->categoryImport->importCategoryAttributes($this->csvFactory->createReader('category_data.csv'));
+    }
+
+    public function importProductsDataOnly()
+    {
+        $this->productImport->importProducts($this->csvFactory->createReader('product.csv'));
+        $this->productImport->importProductData($this->csvFactory->createReader('product_data.csv'));
     }
 
     public function importProducts()

--- a/src/ImportApplication.php
+++ b/src/ImportApplication.php
@@ -54,12 +54,18 @@ class ImportApplication
                 );
             }
 
-            $import = $this->importFactory->create($path, $adapter);
+            $import = $this->importFactory->create($path, $adapter, (bool) $cli->arguments->get('decode_data'));
 
-            $import->importAttributes();
-            $import->importCategories();
-            $import->importProducts();
-            $import->importCustomers();
+            if($cli->arguments->get('attributes_only')) {
+                $import->importAttributesOnly();
+            } elseif($cli->arguments->get('products_data_only')) {
+                $import->importProductsDataOnly();
+            } else {
+                $import->importAttributes();
+                $import->importCategories();
+                $import->importProducts();
+                $import->importCustomers();
+            }
         } catch (InvalidArgumentException $e) {
             $cli->error($e->getMessage());
             $cli->usage();
@@ -98,6 +104,25 @@ class ImportApplication
         $cli->arguments->add('target_path', [
             'description' => 'Import Data Directory',
             'required' => true
+        ]);
+
+        $cli->arguments->add('attributes_only', [
+            'prefix' => 'a',
+            'longPrefix' => 'attributes-only',
+            'description' => 'Only export Attribute data',
+            'defaultValue' => 0
+        ]);
+
+        $cli->arguments->add('products_data_only', [
+            'prefix' => 'po',
+            'longPrefix' => 'products-data-only',
+            'defaultValue' => 0
+        ]);
+
+        $cli->arguments->add('decode_data', [
+            'prefix' => 'dd',
+            'longPrefix' => 'decode-data',
+            'defaultValue' => 0
         ]);
     }
 }

--- a/src/ImportFactory.php
+++ b/src/ImportFactory.php
@@ -13,10 +13,10 @@ use Zend\Db\Adapter\Adapter;
 
 class ImportFactory
 {
-    public function create(string $directory, Adapter $adapter)
+    public function create(string $directory, Adapter $adapter, bool $decodeData = false)
     {
         return new Import(
-            new CsvFactory($directory),
+            new CsvFactory($directory, $decodeData),
             EavMetadataImport::createFromAdapter($adapter),
             CategoryImport::createFromAdapter($adapter),
             ProductImport::createFromAdapter($adapter),

--- a/src/MagentoExport.php
+++ b/src/MagentoExport.php
@@ -67,6 +67,12 @@ class MagentoExport
         $this->productExport->exportConfigurableRelations('product_configurable_relation.csv');
     }
 
+    public function exportProductsDataOnly()
+    {
+        $this->productExport->exportProductList('product.csv');
+        $this->productExport->exportProductData('product_data.csv');
+    }
+
     public function exportCustomers()
     {
         $this->customerExport->exportCustomers('customer.csv');

--- a/src/MagentoExportFactory.php
+++ b/src/MagentoExportFactory.php
@@ -14,13 +14,13 @@ class MagentoExportFactory
 {
     private $configuration = [];
 
-    public function create(string $targetDirectory, Adapter $adapter): MagentoExport
+    public function create(string $targetDirectory, Adapter $adapter, bool $encodeData = false): MagentoExport
     {
         if (!is_dir($targetDirectory)) {
             mkdir($targetDirectory, 0755, true);
         }
 
-        $csvFactory = new CsvFactory($targetDirectory);
+        $csvFactory = new CsvFactory($targetDirectory, $encodeData);
 
         $eavInfo = MagentoEavInfo::createFromAdapter($adapter);
 


### PR DESCRIPTION
Added new options to:

1. import export attribute data only 
2. Import/export product data only
3. Encode data with base 64

On #3 I had issues with product data that broke csv format, due to usage of non ascii/english chars in product data. 
Rather than track all this down in 100 1000's products, it seemed simpler to just base64 encode all data going in/out of csv. Since this is a switch, it should not break any existing functionality, and can be used when needed.
It does slow down import/export a little bt, but still faster than trying to trap all potential data issues/formats

